### PR TITLE
feat: add user registration API with validation

### DIFF
--- a/.github/workflows/auctions-service-ci.yml
+++ b/.github/workflows/auctions-service-ci.yml
@@ -26,7 +26,7 @@ jobs:
           java-version: '17'
 
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/auctions-service-ci.yml
+++ b/.github/workflows/auctions-service-ci.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-version: '17'

--- a/.github/workflows/auctions-service-ci.yml
+++ b/.github/workflows/auctions-service-ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up JDK 17
         uses: actions/setup-java@v2

--- a/.github/workflows/common-ci.yml
+++ b/.github/workflows/common-ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up JDK 17
         uses: actions/setup-java@v2

--- a/.github/workflows/common-ci.yml
+++ b/.github/workflows/common-ci.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-version: '17'

--- a/.github/workflows/common-ci.yml
+++ b/.github/workflows/common-ci.yml
@@ -24,7 +24,7 @@ jobs:
           java-version: '17'
 
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/users-service-ci.yml
+++ b/.github/workflows/users-service-ci.yml
@@ -26,7 +26,7 @@ jobs:
           java-version: '17'
 
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/users-service-ci.yml
+++ b/.github/workflows/users-service-ci.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-version: '17'

--- a/.github/workflows/users-service-ci.yml
+++ b/.github/workflows/users-service-ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up JDK 17
         uses: actions/setup-java@v2

--- a/README.md
+++ b/README.md
@@ -21,3 +21,4 @@ This project is a multi-module Gradle setup for the BidBanker platform. It inclu
 
 ```sh
 ./gradlew build
+```

--- a/Users.http
+++ b/Users.http
@@ -1,0 +1,21 @@
+
+### Successfully create a new User
+POST http://localhost:8080/users/register
+Content-Type: application/json
+
+{
+  "username": "user1",
+  "email": "user1@example.com",
+  "password": "germany"
+}
+
+### Successfully create a new User
+POST http://localhost:8080/users/register
+Content-Type: application/json
+
+{
+  "email": "use",
+  "password": "germany"
+}
+
+###

--- a/Users.http
+++ b/Users.http
@@ -1,21 +1,31 @@
 
 ### Successfully create a new User
-POST http://localhost:8080/users/register
+POST http://localhost:8081/users/register
 Content-Type: application/json
 
 {
-  "username": "user1",
+  "username": "user11",
   "email": "user1@example.com",
   "password": "germany"
 }
 
-### Successfully create a new User
-POST http://localhost:8080/users/register
+### Create new User Validation
+POST http://localhost:8081/users/register
 Content-Type: application/json
 
 {
-  "email": "use",
-  "password": "germany"
+
+}
+
+
+### Create new User Validation
+POST http://localhost:8081/users/register
+Content-Type: application/json
+
+{
+  "username": "n",
+  "email": "g",
+  "password": "n"
 }
 
 ###

--- a/users-service/README.md
+++ b/users-service/README.md
@@ -1,0 +1,41 @@
+# Users Service
+
+The `users-service` is a part of the BidBanker application that manages user registration and retrieval. It is built using Spring Boot, R2DBC, and H2 database with Liquibase for database migrations. The service handles user-related operations such as registering new users.
+
+## Features
+
+- Register new users
+
+## Technologies
+
+- Java 17
+- Spring Boot
+- Spring WebFlux
+- H2 Database
+- Liquibase
+- Project Lombok
+
+## Prerequisites
+
+- Java 17
+- Gradle
+- An IDE like IntelliJ IDEA 
+
+## Setup
+
+**Build the project**:
+
+```bash
+./gradlew users-service:build
+```
+
+**Run the service**:
+
+```bash
+./gradlew users-service:bootRun
+```
+
+## API Testing
+
+
+[Users.http](Users.http) has common API Requests for testing against local endpoints

--- a/users-service/build.gradle.kts
+++ b/users-service/build.gradle.kts
@@ -8,12 +8,25 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter")
     implementation("org.springframework.boot:spring-boot-starter-data-r2dbc")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-data-jdbc")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-webflux")
+
+    implementation("org.liquibase:liquibase-core:4.28.0")
+
     implementation("org.projectlombok:lombok:1.18.20")
     annotationProcessor("org.projectlombok:lombok:1.18.20")
+
     runtimeOnly("com.h2database:h2")
     runtimeOnly("io.r2dbc:r2dbc-h2")
+
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("io.projectreactor:reactor-test")
+    testImplementation("org.hibernate:hibernate-validator-test-utils:5.4.3.Final")
+
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+    systemProperty("spring.profiles.active", "test")
 }

--- a/users-service/build.gradle.kts
+++ b/users-service/build.gradle.kts
@@ -6,6 +6,14 @@ plugins {
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter")
-
+    implementation("org.springframework.boot:spring-boot-starter-data-r2dbc")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("org.springframework.boot:spring-boot-starter-webflux")
+    implementation("org.projectlombok:lombok:1.18.20")
+    annotationProcessor("org.projectlombok:lombok:1.18.20")
+    runtimeOnly("com.h2database:h2")
+    runtimeOnly("io.r2dbc:r2dbc-h2")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("io.projectreactor:reactor-test")
 }

--- a/users-service/src/main/java/com/sougat818/bidbanker/users/UsersApplication.java
+++ b/users-service/src/main/java/com/sougat818/bidbanker/users/UsersApplication.java
@@ -2,8 +2,10 @@ package com.sougat818.bidbanker.users;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.r2dbc.repository.config.EnableR2dbcRepositories;
 
 @SpringBootApplication
+@EnableR2dbcRepositories
 public class UsersApplication {
 
     public static void main(String[] args) {

--- a/users-service/src/main/java/com/sougat818/bidbanker/users/config/ReactiveTransactionConfig.java
+++ b/users-service/src/main/java/com/sougat818/bidbanker/users/config/ReactiveTransactionConfig.java
@@ -1,0 +1,9 @@
+package com.sougat818.bidbanker.users.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+@Configuration
+@EnableTransactionManagement
+public class ReactiveTransactionConfig {
+}

--- a/users-service/src/main/java/com/sougat818/bidbanker/users/controller/UsersController.java
+++ b/users-service/src/main/java/com/sougat818/bidbanker/users/controller/UsersController.java
@@ -4,6 +4,8 @@ import com.sougat818.bidbanker.users.dto.CreateUserRequest;
 import com.sougat818.bidbanker.users.dto.CreateUserResponse;
 import com.sougat818.bidbanker.users.service.UsersService;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
@@ -12,18 +14,17 @@ import reactor.core.publisher.Mono;
 @RestControllerAdvice
 @RequestMapping("/users")
 @Validated
+@RequiredArgsConstructor
 public class UsersController {
 
     private final UsersService usersService;
 
-    public UsersController(UsersService usersService) {
-        this.usersService = usersService;
-    }
-
     @PostMapping("/register")
-    public Mono<CreateUserResponse> registerUser(@RequestBody Mono<@Valid CreateUserRequest> user) {
-        return user.map(usersService::toEntity)
+    public Mono<ResponseEntity<CreateUserResponse>> registerUser(@RequestBody @Valid CreateUserRequest user) {
+        return Mono.just(user)
+                .map(usersService::toEntity)
                 .flatMap(usersService::registerUser)
-                .map(usersService::toResponse);
+                .map(usersService::toResponse)
+                .map(ResponseEntity::ok);
     }
 }

--- a/users-service/src/main/java/com/sougat818/bidbanker/users/controller/UsersController.java
+++ b/users-service/src/main/java/com/sougat818/bidbanker/users/controller/UsersController.java
@@ -1,0 +1,29 @@
+package com.sougat818.bidbanker.users.controller;
+
+import com.sougat818.bidbanker.users.dto.CreateUserRequest;
+import com.sougat818.bidbanker.users.dto.CreateUserResponse;
+import com.sougat818.bidbanker.users.service.UsersService;
+import jakarta.validation.Valid;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RestControllerAdvice
+@RequestMapping("/users")
+@Validated
+public class UsersController {
+
+    private final UsersService usersService;
+
+    public UsersController(UsersService usersService) {
+        this.usersService = usersService;
+    }
+
+    @PostMapping("/register")
+    public Mono<CreateUserResponse> registerUser(@RequestBody Mono<@Valid CreateUserRequest> user) {
+        return user.map(usersService::toEntity)
+                .flatMap(usersService::registerUser)
+                .map(usersService::toResponse);
+    }
+}

--- a/users-service/src/main/java/com/sougat818/bidbanker/users/domain/BidUser.java
+++ b/users-service/src/main/java/com/sougat818/bidbanker/users/domain/BidUser.java
@@ -7,7 +7,7 @@ import jakarta.persistence.*;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class User {
+public class BidUser {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -17,9 +17,9 @@ public class User {
     private String username;
 
     @Column(nullable = false)
-    private String email;
+    private String password;
 
     @Column(nullable = false)
-    private String password;
+    private String email;
 
 }

--- a/users-service/src/main/java/com/sougat818/bidbanker/users/domain/User.java
+++ b/users-service/src/main/java/com/sougat818/bidbanker/users/domain/User.java
@@ -1,0 +1,25 @@
+package com.sougat818.bidbanker.users.domain;
+
+import lombok.*;
+import jakarta.persistence.*;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+}

--- a/users-service/src/main/java/com/sougat818/bidbanker/users/dto/BidBankerErrorResponse.java
+++ b/users-service/src/main/java/com/sougat818/bidbanker/users/dto/BidBankerErrorResponse.java
@@ -1,0 +1,34 @@
+package com.sougat818.bidbanker.users.dto;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+
+@Getter
+public class BidBankerErrorResponse {
+    private final OffsetDateTime timestamp;
+    private final int status;
+    private final String error;
+    private final String message;
+    private final Map<String, String> errors;
+
+    public BidBankerErrorResponse(HttpStatus status, String message) {
+        this.timestamp = OffsetDateTime.now();
+        this.status = status.value();
+        this.error = status.getReasonPhrase();
+        this.message = message;
+        this.errors = null;
+
+    }
+
+    public BidBankerErrorResponse(HttpStatus status, String message, Map<String, String> errors) {
+        this.timestamp = OffsetDateTime.now();
+        this.status = status.value();
+        this.error = status.getReasonPhrase();
+        this.message = message;
+        this.errors = errors;
+    }
+
+}

--- a/users-service/src/main/java/com/sougat818/bidbanker/users/dto/CreateUserRequest.java
+++ b/users-service/src/main/java/com/sougat818/bidbanker/users/dto/CreateUserRequest.java
@@ -1,0 +1,22 @@
+package com.sougat818.bidbanker.users.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record CreateUserRequest(
+        @NotBlank(message = "Username is mandatory")
+        @NotNull
+        @Size(min = 3, max = 20, message = "Username must be between 3 and 20 characters")
+        String username,
+
+        @NotBlank(message = "Password is mandatory")
+        @Size(min = 6, message = "Password must be at least 6 characters")
+        String password,
+
+        @NotBlank(message = "Email is mandatory")
+        @Email(message = "Email should be valid")
+        String email
+) {
+}

--- a/users-service/src/main/java/com/sougat818/bidbanker/users/dto/CreateUserRequest.java
+++ b/users-service/src/main/java/com/sougat818/bidbanker/users/dto/CreateUserRequest.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record CreateUserRequest(
+
         @NotBlank(message = "Username is mandatory")
         @NotNull
         @Size(min = 3, max = 20, message = "Username must be between 3 and 20 characters")

--- a/users-service/src/main/java/com/sougat818/bidbanker/users/dto/CreateUserResponse.java
+++ b/users-service/src/main/java/com/sougat818/bidbanker/users/dto/CreateUserResponse.java
@@ -3,7 +3,7 @@ package com.sougat818.bidbanker.users.dto;
 public record CreateUserResponse(
         Long id,
         String username,
-        String email,
-        String password
+        String password,
+        String email
 ) {
 }

--- a/users-service/src/main/java/com/sougat818/bidbanker/users/dto/CreateUserResponse.java
+++ b/users-service/src/main/java/com/sougat818/bidbanker/users/dto/CreateUserResponse.java
@@ -1,0 +1,9 @@
+package com.sougat818.bidbanker.users.dto;
+
+public record CreateUserResponse(
+        Long id,
+        String username,
+        String email,
+        String password
+) {
+}

--- a/users-service/src/main/java/com/sougat818/bidbanker/users/exceptions/BadRequestException.java
+++ b/users-service/src/main/java/com/sougat818/bidbanker/users/exceptions/BadRequestException.java
@@ -1,0 +1,7 @@
+package com.sougat818.bidbanker.users.exceptions;
+
+public class BadRequestException extends RuntimeException {
+    public BadRequestException(String message) {
+        super(message);
+    }
+}

--- a/users-service/src/main/java/com/sougat818/bidbanker/users/exceptions/ConflictException.java
+++ b/users-service/src/main/java/com/sougat818/bidbanker/users/exceptions/ConflictException.java
@@ -1,0 +1,7 @@
+package com.sougat818.bidbanker.users.exceptions;
+
+public class ConflictException extends RuntimeException {
+    public ConflictException(String message) {
+        super(message);
+    }
+}

--- a/users-service/src/main/java/com/sougat818/bidbanker/users/exceptions/GlobalExceptionHandler.java
+++ b/users-service/src/main/java/com/sougat818/bidbanker/users/exceptions/GlobalExceptionHandler.java
@@ -1,0 +1,63 @@
+package com.sougat818.bidbanker.users.exceptions;
+
+import com.sougat818.bidbanker.users.dto.BidBankerErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.support.WebExchangeBindException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@ControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+
+    @ExceptionHandler(NotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ResponseEntity<BidBankerErrorResponse> handleNotFoundException(NotFoundException ex) {
+        BidBankerErrorResponse errorResponse = new BidBankerErrorResponse(HttpStatus.NOT_FOUND, ex.getMessage());
+        return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(BadRequestException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<BidBankerErrorResponse> handleBadRequestException(BadRequestException ex) {
+        BidBankerErrorResponse errorResponse = new BidBankerErrorResponse(HttpStatus.BAD_REQUEST, ex.getMessage());
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(ConflictException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public ResponseEntity<BidBankerErrorResponse> handleConflictException(ConflictException ex) {
+        BidBankerErrorResponse errorResponse = new BidBankerErrorResponse(HttpStatus.CONFLICT, ex.getMessage());
+        return new ResponseEntity<>(errorResponse, HttpStatus.CONFLICT);
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ResponseEntity<BidBankerErrorResponse> handleRuntimeException(RuntimeException ex) {
+        log.error("Unexpected exception: ", ex);
+        BidBankerErrorResponse errorResponse = new BidBankerErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR,
+                null);
+        return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(WebExchangeBindException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<BidBankerErrorResponse> handleValidationExceptions(WebExchangeBindException ex) {
+        Map<String, String> errors = new HashMap<>();
+        ex.getBindingResult().getAllErrors().forEach(error -> {
+            String fieldName = ((FieldError) error).getField();
+            String errorMessage = error.getDefaultMessage();
+            errors.put(fieldName, errorMessage);
+        });
+        return new ResponseEntity<>(new BidBankerErrorResponse(HttpStatus.BAD_REQUEST, "Validation Failed", errors),
+                HttpStatus.BAD_REQUEST);
+    }
+}

--- a/users-service/src/main/java/com/sougat818/bidbanker/users/exceptions/NotFoundException.java
+++ b/users-service/src/main/java/com/sougat818/bidbanker/users/exceptions/NotFoundException.java
@@ -1,0 +1,7 @@
+package com.sougat818.bidbanker.users.exceptions;
+
+public class NotFoundException extends RuntimeException {
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/users-service/src/main/java/com/sougat818/bidbanker/users/repository/UsersRepository.java
+++ b/users-service/src/main/java/com/sougat818/bidbanker/users/repository/UsersRepository.java
@@ -1,4 +1,10 @@
 package com.sougat818.bidbanker.users.repository;
 
-public class UsersRepository {
+import com.sougat818.bidbanker.users.domain.BidUser;
+import org.springframework.data.r2dbc.repository.R2dbcRepository;
+import reactor.core.publisher.Mono;
+
+public interface UsersRepository extends R2dbcRepository<BidUser, Long> {
+
+    Mono<BidUser> findByUsername(String username);
 }

--- a/users-service/src/main/java/com/sougat818/bidbanker/users/repository/UsersRepository.java
+++ b/users-service/src/main/java/com/sougat818/bidbanker/users/repository/UsersRepository.java
@@ -1,0 +1,4 @@
+package com.sougat818.bidbanker.users.repository;
+
+public class UsersRepository {
+}

--- a/users-service/src/main/java/com/sougat818/bidbanker/users/service/UsersService.java
+++ b/users-service/src/main/java/com/sougat818/bidbanker/users/service/UsersService.java
@@ -1,0 +1,25 @@
+package com.sougat818.bidbanker.users.service;
+
+import com.sougat818.bidbanker.users.domain.User;
+import com.sougat818.bidbanker.users.dto.CreateUserRequest;
+import com.sougat818.bidbanker.users.dto.CreateUserResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import reactor.core.publisher.Mono;
+
+@Service
+public class UsersService {
+    @Transactional
+    public Mono<User> registerUser(User user) {
+        return Mono.just(user);
+    }
+
+
+    public User toEntity(CreateUserRequest request) {
+        return new User(null, request.username(), request.email(), request.password());
+    }
+
+    public CreateUserResponse toResponse(User user) {
+        return new CreateUserResponse(user.getId(), user.getUsername(), user.getEmail(), user.getPassword());
+    }
+}

--- a/users-service/src/main/java/com/sougat818/bidbanker/users/service/UsersService.java
+++ b/users-service/src/main/java/com/sougat818/bidbanker/users/service/UsersService.java
@@ -1,25 +1,43 @@
 package com.sougat818.bidbanker.users.service;
 
-import com.sougat818.bidbanker.users.domain.User;
+import com.sougat818.bidbanker.users.domain.BidUser;
 import com.sougat818.bidbanker.users.dto.CreateUserRequest;
 import com.sougat818.bidbanker.users.dto.CreateUserResponse;
+import com.sougat818.bidbanker.users.exceptions.ConflictException;
+import com.sougat818.bidbanker.users.repository.UsersRepository;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Mono;
 
 @Service
+@RequiredArgsConstructor
+@Slf4j
 public class UsersService {
+
+    private final UsersRepository usersRepository;
+
     @Transactional
-    public Mono<User> registerUser(User user) {
-        return Mono.just(user);
+    public Mono<BidUser> registerUser(@NonNull BidUser bidUser) {
+        return usersRepository.save(bidUser)
+                .map(BidUser::getUsername)
+                // https://github.com/spring-projects/spring-data-relational/issues/1274
+                .flatMap(usersRepository::findByUsername)
+                .onErrorResume(DuplicateKeyException.class,
+                        e -> Mono.error(new ConflictException("User already exists.")));
+
     }
 
 
-    public User toEntity(CreateUserRequest request) {
-        return new User(null, request.username(), request.email(), request.password());
+    public BidUser toEntity(CreateUserRequest request) {
+        return new BidUser(null, request.username(), request.password(), request.email());
     }
 
-    public CreateUserResponse toResponse(User user) {
-        return new CreateUserResponse(user.getId(), user.getUsername(), user.getEmail(), user.getPassword());
+    public CreateUserResponse toResponse(BidUser bidUser) {
+        return new CreateUserResponse(bidUser.getId(), bidUser.getUsername(),
+                bidUser.getPassword(), bidUser.getEmail());
     }
 }

--- a/users-service/src/main/resources/application.properties
+++ b/users-service/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=users

--- a/users-service/src/main/resources/application.yaml
+++ b/users-service/src/main/resources/application.yaml
@@ -1,0 +1,18 @@
+spring:
+  application:
+    name: users
+  r2dbc:
+    url: r2dbc:h2:mem:///users;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+#    url: r2dbc:h2:file:////Users/sougatakhan/code/BidBanker/users;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+  liquibase:
+    enabled: true
+    url: jdbc:h2:mem:users;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+#    url: jdbc:h2:file:///Users/sougatakhan/code/BidBanker/users;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    change-log: classpath:db/changelog/db.changelog-master.yaml
+  h2:
+    console:
+      enabled: true
+  flyway:
+    enabled: false
+server:
+  port: 8081

--- a/users-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/users-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,0 +1,30 @@
+databaseChangeLog:
+  - changeSet:
+      id: 1
+      author: sougat818
+      changes:
+        - createTable:
+            tableName: bid_user
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+              - column:
+                  name: username
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+                    unique: true
+              - column:
+                  name: email
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: password
+                  type: VARCHAR(255)
+                  constraints:
+                    nullable: false

--- a/users-service/src/test/java/com/sougat818/bidbanker/users/controller/UsersControllerTest.java
+++ b/users-service/src/test/java/com/sougat818/bidbanker/users/controller/UsersControllerTest.java
@@ -1,0 +1,58 @@
+package com.sougat818.bidbanker.users.controller;
+
+import com.sougat818.bidbanker.users.domain.BidUser;
+import com.sougat818.bidbanker.users.dto.CreateUserRequest;
+import com.sougat818.bidbanker.users.dto.CreateUserResponse;
+import com.sougat818.bidbanker.users.service.UsersService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Mono;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+class UsersControllerTest {
+
+    @Mock
+    private UsersService usersService;
+
+    @InjectMocks
+    private UsersController usersController;
+
+    private WebTestClient webTestClient;
+
+    private BidUser bidUser;
+    private CreateUserRequest createUserRequest;
+    private CreateUserResponse createUserResponse;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        webTestClient = WebTestClient.bindToController(usersController).build();
+        bidUser = new BidUser(1L, "username", "email@example.com", "password");
+        createUserRequest = new CreateUserRequest("username", "password", "email@example.com");
+        createUserResponse = new CreateUserResponse(1L, "username", "password", "email@example.com");
+    }
+
+    @Test
+    void testCreateUser_Success() {
+        when(usersService.registerUser(any(BidUser.class))).thenReturn(Mono.just(bidUser));
+        when(usersService.toResponse(any(BidUser.class))).thenReturn(createUserResponse);
+        when(usersService.toEntity(any(CreateUserRequest.class))).thenReturn(bidUser);
+
+        webTestClient.post()
+                .uri("/users/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(createUserRequest)
+                .exchange()
+                .expectStatus().is2xxSuccessful()
+                .expectBody(CreateUserResponse.class)
+                .isEqualTo(createUserResponse);
+    }
+
+}

--- a/users-service/src/test/java/com/sougat818/bidbanker/users/dto/CreateUserRequestValidationTest.java
+++ b/users-service/src/test/java/com/sougat818/bidbanker/users/dto/CreateUserRequestValidationTest.java
@@ -1,0 +1,104 @@
+package com.sougat818.bidbanker.users.dto;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CreateUserRequestValidationTest {
+
+    private Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Test
+    void testValidCreateUserRequest() {
+        CreateUserRequest user = new CreateUserRequest("username", "password", "email@example.com");
+        Set<ConstraintViolation<CreateUserRequest>> violations = validator.validate(user);
+        assertThat(violations.size()).isEqualTo(0);
+    }
+
+    @Test
+    void testUsernameNotNull() {
+        CreateUserRequest createUserRequest = new CreateUserRequest(null, "password", "email@example.com");
+        Set<String> violationMessages =
+                validator.validate(createUserRequest).stream().map(ConstraintViolation::getMessage)
+                        .collect(Collectors.toSet());
+
+        Set<String> expectedMessages = Set.of("Username is mandatory", "must not be null");
+
+        assertThat(violationMessages.size()).isEqualTo(2);
+        assertThat(violationMessages).containsAll(expectedMessages);
+
+    }
+
+    @Test
+    void testUsernameNotBlank() {
+        CreateUserRequest createUserRequest = new CreateUserRequest("", "password", "email@example.com");
+        Set<String> violationMessages =
+                validator.validate(createUserRequest).stream().map(ConstraintViolation::getMessage)
+                        .collect(Collectors.toSet());
+
+        Set<String> expectedMessages = Set.of("Username is mandatory", "Username must be between 3 and 20 characters");
+
+        assertThat(violationMessages.size()).isEqualTo(2);
+        assertThat(violationMessages).containsAll(expectedMessages);
+    }
+
+    @Test
+    void testUsernameNotValid() {
+        CreateUserRequest createUserRequest = new CreateUserRequest("a", "password", "email@example.com");
+        Set<String> violationMessages =
+                validator.validate(createUserRequest).stream().map(ConstraintViolation::getMessage)
+                        .collect(Collectors.toSet());
+
+        Set<String> expectedMessages = Set.of("Username must be between 3 and 20 characters");
+
+        assertThat(violationMessages.size()).isEqualTo(1);
+        assertThat(violationMessages).containsAll(expectedMessages);
+    }
+
+    @Test
+    void testEmailNotNull() {
+        CreateUserRequest createUserRequest = new CreateUserRequest("username", "password", null);
+        Set<ConstraintViolation<CreateUserRequest>> violations = validator.validate(createUserRequest);
+        assertThat(violations.size()).isEqualTo(1);
+        assertThat(violations.iterator().next().getMessage()).isEqualTo("Email is mandatory");
+    }
+
+
+    @Test
+    void testEmailValid() {
+        CreateUserRequest createUserRequest = new CreateUserRequest("username", "password", "invalid-email");
+        Set<ConstraintViolation<CreateUserRequest>> violations = validator.validate(createUserRequest);
+        assertThat(violations.size()).isEqualTo(1);
+        assertThat(violations.iterator().next().getMessage()).isEqualTo("Email should be valid");
+    }
+
+    @Test
+    void testPasswordNotNull() {
+        CreateUserRequest createUserRequest = new CreateUserRequest("username", null, "email@example.com");
+        Set<ConstraintViolation<CreateUserRequest>> violations = validator.validate(createUserRequest);
+        assertThat(violations.size()).isEqualTo(1);
+        assertThat(violations.iterator().next().getMessage()).isEqualTo("Password is mandatory");
+    }
+
+    @Test
+    void testPasswordNotValid() {
+        CreateUserRequest createUserRequest = new CreateUserRequest("username", "a", "email@example.com");
+        Set<ConstraintViolation<CreateUserRequest>> violations = validator.validate(createUserRequest);
+        assertThat(violations.size()).isEqualTo(1);
+        assertThat(violations.iterator().next().getMessage()).isEqualTo("Password must be at least 6 characters");
+    }
+}

--- a/users-service/src/test/java/com/sougat818/bidbanker/users/exceptions/GlobalExceptionHandlerTest.java
+++ b/users-service/src/test/java/com/sougat818/bidbanker/users/exceptions/GlobalExceptionHandlerTest.java
@@ -1,0 +1,102 @@
+package com.sougat818.bidbanker.users.exceptions;
+
+import com.sougat818.bidbanker.users.dto.BidBankerErrorResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.support.WebExchangeBindException;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class GlobalExceptionHandlerTest {
+
+    @InjectMocks
+    private GlobalExceptionHandler globalExceptionHandler;
+
+    @BeforeEach
+    void setUp() {
+        globalExceptionHandler = new GlobalExceptionHandler();
+    }
+
+    @Test
+    void handleConflictException() {
+        ConflictException exception = new ConflictException("Conflict occurred");
+        ResponseEntity<BidBankerErrorResponse> response = globalExceptionHandler.handleConflictException(exception);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+        assertThat(response.getBody().getError()).isEqualTo("Conflict");
+        assertThat(response.getBody().getMessage()).isEqualTo("Conflict occurred");
+        assertThat(response.getBody().getStatus()).isEqualTo(HttpStatus.CONFLICT.value());
+        assertThat(response.getBody().getErrors()).isNull();
+        assertThat(response.getBody().getTimestamp()).isNotNull();
+    }
+
+    @Test
+    void handleNotFoundException() {
+        NotFoundException exception = new NotFoundException("Not found");
+        ResponseEntity<BidBankerErrorResponse> response = globalExceptionHandler.handleNotFoundException(exception);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(response.getBody().getError()).isEqualTo("Not Found");
+        assertThat(response.getBody().getMessage()).isEqualTo("Not found");
+        assertThat(response.getBody().getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
+        assertThat(response.getBody().getErrors()).isNull();
+        assertThat(response.getBody().getTimestamp()).isNotNull();
+
+
+    }
+
+    @Test
+    void handleBadRequestException() {
+        BadRequestException exception = new BadRequestException("Bad request");
+        ResponseEntity<BidBankerErrorResponse> response = globalExceptionHandler.handleBadRequestException(exception);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody().getError()).isEqualTo("Bad Request");
+        assertThat(response.getBody().getMessage()).isEqualTo("Bad request");
+        assertThat(response.getBody().getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(response.getBody().getErrors()).isNull();
+        assertThat(response.getBody().getTimestamp()).isNotNull();
+
+
+    }
+
+    @Test
+    void handleRuntimeException() {
+        RuntimeException exception = new RuntimeException("Runtime error");
+        ResponseEntity<BidBankerErrorResponse> response = globalExceptionHandler.handleRuntimeException(exception);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(response.getBody().getError()).isEqualTo("Internal Server Error");
+        assertThat(response.getBody().getMessage()).isNull();
+        assertThat(response.getBody().getStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
+        assertThat(response.getBody().getErrors()).isNull();
+        assertThat(response.getBody().getTimestamp()).isNotNull();
+
+
+    }
+
+    @Test
+    void handleValidationExceptions() {
+        BindException bindException = new BindException(new Object(), "target");
+        bindException.addError(new FieldError("objectName", "fieldName", "defaultMessage"));
+        WebExchangeBindException exception = new WebExchangeBindException(null, bindException.getBindingResult());
+        ResponseEntity<BidBankerErrorResponse> response = globalExceptionHandler.handleValidationExceptions(exception);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody().getError()).startsWith("Bad Request");
+        assertThat(response.getBody().getMessage()).startsWith("Validation Failed");
+        assertThat(response.getBody().getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(response.getBody().getErrors()).isEqualTo(Map.of("fieldName", "defaultMessage"));
+        assertThat(response.getBody().getTimestamp()).isNotNull();
+
+    }
+}

--- a/users-service/src/test/java/com/sougat818/bidbanker/users/service/UsersServiceTest.java
+++ b/users-service/src/test/java/com/sougat818/bidbanker/users/service/UsersServiceTest.java
@@ -1,0 +1,80 @@
+package com.sougat818.bidbanker.users.service;
+
+import com.sougat818.bidbanker.users.domain.BidUser;
+import com.sougat818.bidbanker.users.dto.CreateUserRequest;
+import com.sougat818.bidbanker.users.dto.CreateUserResponse;
+import com.sougat818.bidbanker.users.exceptions.ConflictException;
+import com.sougat818.bidbanker.users.repository.UsersRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.dao.DuplicateKeyException;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+class UsersServiceTest {
+
+    @Mock
+    private UsersRepository usersRepository;
+
+    @InjectMocks
+    private UsersService usersService;
+
+    private BidUser bidUser;
+    private CreateUserRequest createUserRequest;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        bidUser = new BidUser(1L, "username", "password", "email@example.com");
+        createUserRequest = new CreateUserRequest("username", "password", "email@example.com");
+    }
+
+    @Test
+    void testRegisterUser_Success() {
+        when(usersRepository.save(any(BidUser.class))).thenReturn(Mono.just(bidUser));
+        when(usersRepository.findByUsername(anyString())).thenReturn(Mono.just(bidUser));
+
+        Mono<BidUser> result = usersService.registerUser(bidUser);
+
+        StepVerifier.create(result)
+                .expectNext(bidUser)
+                .verifyComplete();
+    }
+
+    @Test
+    void testRegisterUser_UserAlreadyExists() {
+        when(usersRepository.save(any(BidUser.class))).thenReturn(Mono.error(new DuplicateKeyException("User already " +
+                                                                                                       "exists")));
+
+        Mono<BidUser> result = usersService.registerUser(bidUser);
+
+        StepVerifier.create(result)
+                .expectError(ConflictException.class)
+                .verify();
+    }
+
+    @Test
+    void testToEntity() {
+        BidUser result = usersService.toEntity(createUserRequest);
+        assertThat(result.getUsername()).isEqualTo(createUserRequest.username());
+        assertThat(result.getEmail()).isEqualTo(createUserRequest.email());
+        assertThat(result.getPassword()).isEqualTo(createUserRequest.password());
+    }
+
+    @Test
+    void testToResponse() {
+        CreateUserResponse result = usersService.toResponse(bidUser);
+        assertThat(result.id()).isEqualTo(bidUser.getId());
+        assertThat(result.username()).isEqualTo(bidUser.getUsername());
+        assertThat(result.email()).isEqualTo(bidUser.getEmail());
+        assertThat(result.password()).isEqualTo(bidUser.getPassword());
+    }
+}

--- a/users-service/src/test/resources/application-test.yaml
+++ b/users-service/src/test/resources/application-test.yaml
@@ -1,0 +1,20 @@
+spring:
+  application:
+    name: users-test
+  r2dbc:
+    url: r2dbc:h2:mem:///userstest;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+  liquibase:
+    enabled: true
+    url: jdbc:h2:mem:userstest;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    change-log: classpath:db/changelog/db.changelog-master.yaml
+  h2:
+    console:
+      enabled: true
+  flyway:
+    enabled: false
+server:
+  port: 9081
+logging:
+  level:
+    root: DEBUG
+    org.springframework: DEBUG


### PR DESCRIPTION
- Implement user registration endpoint at `/register`
- Create `CreateUserRequest`, `CreateUserResponse` records with validations
- Add User Domain Model
 - Implemented register user with tests
- Added Global Exception Handler
- Implemented liquibase support for database changes